### PR TITLE
Send logout message before stopping initiators

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
+++ b/quickfixj-core/src/main/java/quickfix/ThreadedSocketInitiator.java
@@ -82,11 +82,12 @@ public class ThreadedSocketInitiator extends AbstractSocketInitiator {
     }
 
     public void stop(boolean forceDisconnect) {
-        stopInitiators();
         logoutAllSessions(forceDisconnect);
+        stopSessionTimer();
         if (!forceDisconnect) {
             waitForLogout();
         }
+        stopInitiators();
         eventHandlingStrategy.stopDispatcherThreads();
         Session.unregisterSessions(getSessions());
     }


### PR DESCRIPTION
Because logout sets a flag indicating we should logout, we rely on another thread to send the logout message.

If we stop the initiators first that doesn't happen.

See JIRA: (QFJ-885)[http://www.quickfixj.org/jira/browse/QFJ-885]